### PR TITLE
Added dts for opentitan

### DIFF
--- a/dts/manufacturer/lowrisc/opentitan_earlgrey.dtsi
+++ b/dts/manufacturer/lowrisc/opentitan_earlgrey.dtsi
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023 by Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+/ {
+	#address-cells = <0x01>;
+	#size-cells = <0x01>;
+	compatible = "lowrisc,opentitan-earlgrey";
+	model = "opentitan-earlgrey,qemu";
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+
+		cpu@0 {
+			device_type = "cpu";
+			reg = <0x00>;
+			status = "okay";
+			compatible = "lowrisc,ibex", "riscv";
+			riscv,isa = "rv32imcb_zicsr_zifencei";
+
+			hlic: interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+			};
+		};
+	};
+
+	soc {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		compatible = "simple-bus";
+		ranges;
+
+		flash0: flash@20000000 {
+			reg = <0x20000000 0x100000>;
+			compatible = "soc-nv-flash";
+		};
+
+		ram0: memory@10000000 {
+			device_type = "memory";
+			reg = <0x10000000 0x10000>;
+			compatible = "mmio-sram";
+		};
+
+		mtimer: timer@40100110 {
+			compatible = "riscv,machine-timer";
+			reg = <0x40100110 0x8 0x40100118 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts-extended = <&hlic 7>;
+		};
+
+		aontimer: aontimer@40470000 {
+			compatible = "lowrisc,opentitan-aontimer";
+			reg = <0x40470000 0x1000>;
+			interrupts = <156 1>;
+			interrupt-names = "wdog_bark";
+			interrupt-parent = <&plic>;
+			clock-frequency = <200000>;
+			status = "disabled";
+		};
+
+		pwrmgr: pwrmgr@40400000 {
+			compatible = "lowrisc,opentitan-pwrmgr";
+			reg = <0x40400000 0x80>;
+			status = "okay";
+		};
+
+		plic: interrupt-controller@48000000 {
+			compatible = "sifive,plic-1.0.0";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
+			interrupt-controller;
+			interrupts-extended = <&hlic 11>;
+			reg = <0x48000000 0x04000000>;
+			riscv,max-priority = <7>;
+			riscv,ndev = <182>;
+			status = "okay";
+		};
+
+		uart0: serial@40000000{
+			reg = <0x40000000 0x1000>;
+			compatible = "lowrisc,opentitan-uart";
+			status = "disabled";
+		};
+
+		spi0: spi@40300000 {
+			compatible = "lowrisc,opentitan-spi";
+			status = "disabled";
+			reg = <0x40300000 0x100>;
+			clock-frequency = <96000000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		spi1: spi@40310000 {
+			compatible = "lowrisc,opentitan-spi";
+			status = "disabled";
+			reg = <0x40310000 0x100>;
+			clock-frequency = <48000000>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		pinctrl: pin-controller@40040000 {
+			compatible = "lowrisc,opt-gpio";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <40040000 0x400>;
+
+			gpioa: gpio@40040000 {
+				compatible = "lowrisc,opt-gpio";
+				gpio-controller;
+				#gpio-cells = <32>;
+				reg = <40040000 0x400>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
Added dtsi for opentitan earlgrey board.

DTS is based on Zephyr : https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/riscv/lowrisc/opentitan_earlgrey.dtsi.

Modifications for sentry:

- Declare ram0 as "compatible = "mmio-sram";". It necessary to recognise it in the linker script creation.
- Added gpioa declariation. needed to be recognized in the gpio driver